### PR TITLE
Fix processing cookie

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -6399,7 +6399,7 @@ public class Wiki implements Serializable
     {
         String headerName;
         for (int i = 1; (headerName = u.getHeaderFieldKey(i)) != null; i++)
-            if (headerName.equals("Set-Cookie"))
+            if (headerName.equalsIgnoreCase("Set-Cookie"))
             {
                 String cookie = u.getHeaderField(i);
                 if(cookie.contains("=deleted")) continue;


### PR DESCRIPTION
Vicuna was processing only Set-Cookie, not set-cookie.
In https://phabricator.wikimedia.org/T249526 are information about new
set-cookie in header.

Change is about processing Set-Cookie in case-insensitive way.