### PR TITLE
Update Gradle for Java 16 compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Jul 04 19:13:21 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://docs.gradle.org/7.0.2/release-notes.html#java-16

> As of Gradle 7.0, both running Gradle itself and building JVM projects with Java 16 is fully supported.