### PR TITLE
Move downloading of libraries to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,7 @@ plugins {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
jcenter is obsolete (https://blog.gradle.org/jcenter-shutdown)
Build was tested.